### PR TITLE
Bump-up-dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@slidev/cli": "^52.0.0",
         "@slidev/theme-default": "^0.25.0",
         "@slidev/theme-seriph": "^0.25.0",
-        "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.0",
         "slidev-addon-components": "^0.0.1",
         "slidev-addon-rabbit": "^0.4.0"
       },
@@ -34,6 +33,7 @@
         "@iconify-json/ph": "^1.2.2",
         "@iconify-json/simple-icons": "^1.2.44",
         "@iconify-json/tabler": "^1.2.20",
+        "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.0",
         "playwright-chromium": "^1.54.1",
         "textlint": "^15.2.0",
         "textlint-filter-rule-comments": "^1.2.2",
@@ -1358,6 +1358,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@kvs/env/-/env-2.2.0.tgz",
       "integrity": "sha512-G66d4q8ATY7jsKz6KovHE9ScQ4HSs9BtkRUiLMVI/nHeHHA+KDt4qYZQ2KmaC9LPIAc7bJmR7uAH8DTBamJKhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kvs/indexeddb": "^2.1.4",
@@ -1368,6 +1369,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@kvs/indexeddb/-/indexeddb-2.1.4.tgz",
       "integrity": "sha512-7xIF5hLREZFXnsYnR51LTAaO+pWFDMoBzF2vdl/RVnPP+7/WJS+7npO1aZ+EDrAMeJwAARhXFF/3NI3Wy3DCXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kvs/types": "^2.1.4"
@@ -1377,6 +1379,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@kvs/node-localstorage/-/node-localstorage-2.2.0.tgz",
       "integrity": "sha512-ADvFxbCZF2t4vzwU2Ng3I7+vviSLTc5bkCGgVUeEfcRqaM781ZAO5bHn9kiYUIziIf5fESkOnQxrJQqmQtpI0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kvs/storage": "^2.1.4",
@@ -1388,6 +1391,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@kvs/storage/-/storage-2.1.4.tgz",
       "integrity": "sha512-d4sdTdCjAsyX9v9Q3rFciG9rUs24KNIMUzRv3fVIpbehlnfTWZ5TACucN6LAMFZaqgEnBKLxghwfUCrsaYDzig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kvs/types": "^2.1.4"
@@ -1397,6 +1401,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@kvs/types/-/types-2.1.4.tgz",
       "integrity": "sha512-XtTOUatnJrDcuYNPfN+9x1xuVp11IuyPi9zOLVJPpfnKp+vUCatka/Crp2cfz0uKt4QE1Pb4Dg/TNYgVYA2Org==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -2505,6 +2510,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@textlint-ja/textlint-rule-preset-ai-writing/-/textlint-rule-preset-ai-writing-1.6.0.tgz",
       "integrity": "sha512-PwPQfNrbQMUBMmCUw0Yf1qK1zxV3HS5dyAT0gTnjj1g0sbvs8NRbj5znunrXqst61savayDlPbrl23tqoFCHbQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@textlint/regexp-string-matcher": "^2.0.2",
@@ -2781,6 +2787,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-2.0.2.tgz",
       "integrity": "sha512-OXLD9XRxMhd3S0LWuPHpiARQOI7z9tCOs0FsynccW2lmyZzHHFJ9/eR6kuK9xF459Qf+740qI5h+/0cx+NljzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
@@ -2793,6 +2800,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4172,6 +4180,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
       "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
@@ -4246,6 +4255,7 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
@@ -4281,6 +4291,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
       "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4398,6 +4409,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
       "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
@@ -6149,6 +6161,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
       "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/drauu": {
@@ -6676,6 +6689,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/extend-shallow": {
@@ -7465,6 +7479,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
       "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ccount": "^1.0.3",
@@ -7482,6 +7497,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7492,6 +7508,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -7505,6 +7522,7 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
       "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -7551,6 +7569,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
       "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "comma-separated-tokens": "^1.0.0",
@@ -7567,6 +7586,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7577,6 +7597,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -7590,6 +7611,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7804,6 +7826,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -8316,6 +8339,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8731,6 +8755,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
       "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^2.0.1",
@@ -8742,6 +8767,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-3.0.1.tgz",
       "integrity": "sha512-E4rLmbTid8ZGH8Fw421UXvfgCe0IXGFKhUw/IosBVW6ootxVGKGbtb0UPQAvPswgsXX/8UuPiE+amz1NN11Uzg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kvs/env": "^2.1.3",
@@ -8824,6 +8850,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -8836,6 +8863,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.truncate": {
@@ -8849,12 +8877,14 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniqwith": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
       "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -8883,6 +8913,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
       "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -10400,6 +10431,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
       "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "write-file-atomic": "^1.1.4"
@@ -10743,6 +10775,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/parseurl": {
@@ -11574,6 +11607,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
       "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hast-util-from-parse5": "^5.0.0",
@@ -12699,6 +12733,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "*"
@@ -13036,6 +13071,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
       "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boundary": "^2.0.0"
@@ -14093,6 +14129,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.3.4.tgz",
       "integrity": "sha512-XF4Qfw0ES+czKy03BwuvBUoXC8NAg920VuRxW0pd72fW76zMeMbPI/bRN5PHq3SbCdOm7U69/Pk+DX34xqIYqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@textlint/ast-node-types": "^13.4.1",
@@ -14105,18 +14142,21 @@
       "version": "13.4.1",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-13.4.1.tgz",
       "integrity": "sha512-qrZyhCh8Ekk6nwArx3BROybm9BnX6vF7VcZbijetV/OM3yfS4rTYhoMWISmhVEP2H2re0CtWEyMl/XF+WdvVLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/textlint-util-to-string/node_modules/@types/unist": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/textlint-util-to-string/node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14140,6 +14180,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
       "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bail": "^1.0.0",
@@ -14157,6 +14198,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
       "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.2"
@@ -14170,6 +14212,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
       "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14186,6 +14229,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
       "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -14348,6 +14392,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -15657,6 +15702,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -15905,6 +15951,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "graceful-fs": "^4.1.11",
@@ -15931,6 +15978,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -16043,6 +16091,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
       "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@iconify-json/tabler": "^1.2.20",
         "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.0",
         "playwright-chromium": "^1.54.1",
-        "textlint": "^15.2.0",
+        "textlint": "^15.2.1",
         "textlint-filter-rule-comments": "^1.2.2",
         "textlint-rule-preset-ja-spacing": "^2.4.3",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2"
@@ -393,13 +393,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1464,9 +1464,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.16.0.tgz",
-      "integrity": "sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.0.tgz",
+      "integrity": "sha512-qFfbWFA7r1Sd8D697L7GkTd36yqDuTkvz0KfOGkgXR8EUhQn3/EDNIR/qUdQNMT8IjmasBvHWuXeisxtXTQT2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2537,66 +2537,66 @@
       }
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.2.0.tgz",
-      "integrity": "sha512-nr9wEiZCNYafGZ++uWFZgPlDX3Bi7u4T2d5swpaoMvc1G2toXsBfe7UNVwXZq5dvYDbQN7vDeb3ltlKQ8JnPNQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.2.1.tgz",
+      "integrity": "sha512-20fEcLPsXg81yWpApv4FQxrZmlFF/Ta7/kz1HGIL+pJo5cSTmkc+eCki3GpOPZIoZk0tbJU8hrlwUb91F+3SNQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/ast-tester": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-15.2.0.tgz",
-      "integrity": "sha512-NuTwgRrjND1JkEPWenuYMO5KAnjkQHDuGStyKSxNHpHTFOuDBw+IRJkdJIbbkFMzkotvNYh/4u94Cjq5YHQq+w==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-15.2.1.tgz",
+      "integrity": "sha512-B3BNE52w+6eCsybpKhxIm/bMY1i3oF8AC5amYeaPaTaluz+rPDR4S5S6QAMaMM8XJlD0osYBdKd9LDwQPJFsIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.2.0",
+        "@textlint/ast-node-types": "15.2.1",
         "debug": "^4.4.1"
       }
     },
     "node_modules/@textlint/ast-traverse": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-15.2.0.tgz",
-      "integrity": "sha512-2nLcu2MJZ00n5O9ui4r+r3dVWIuv//Zx/TV+cne0RYr1OvqMpgPnWarcmAXvRqxFakd7cNwXFUKLANa1cs7Mog==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-15.2.1.tgz",
+      "integrity": "sha512-6i+kqjREEJ1HH3v0tltQ1ZTgptd4ViyJiZe+5J62Bn1Ml7CyV/zIJ4+3pJ4x26Ts+1sqpUD/lDDNOeZz5DKsmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.2.0"
+        "@textlint/ast-node-types": "15.2.1"
       }
     },
     "node_modules/@textlint/config-loader": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-15.2.0.tgz",
-      "integrity": "sha512-c8oK7h/JG95Dp098FOTZ1apctZuCUQ8zfaHDOUPo+H3Ive0gNhuxuPrwLdlQAaFxJD9833BjwFgfNeeRyTtd4Q==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-15.2.1.tgz",
+      "integrity": "sha512-Rxp9YUAyYDmy6VIFJ0aNE/18O920wGCJpAVok+TnW8VM/CJXTp6/UibgSkqjWM5W2K301AFhZgPENAWJQLP7yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/kernel": "15.2.0",
-        "@textlint/module-interop": "15.2.0",
-        "@textlint/resolver": "15.2.0",
-        "@textlint/types": "15.2.0",
-        "@textlint/utils": "15.2.0",
+        "@textlint/kernel": "15.2.1",
+        "@textlint/module-interop": "15.2.1",
+        "@textlint/resolver": "15.2.1",
+        "@textlint/types": "15.2.1",
+        "@textlint/utils": "15.2.1",
         "debug": "^4.4.1",
         "rc-config-loader": "^4.1.3"
       }
     },
     "node_modules/@textlint/feature-flag": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-15.2.0.tgz",
-      "integrity": "sha512-bxtFeKHot/9CF4APlXiwZmKHeKZfjSMqRgLKJIonof3NWAIprWdpNSz0Jr8Goe/fp3sUdKb+lyWBtszy1Fkn9A==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-15.2.1.tgz",
+      "integrity": "sha512-88H5WGxTperDNHA6LXT6AcTJ9MFs9l1OR7fjq+0AbXjq8Fg5RFYgx0SCxr4Fcmx0nr8JOFhexXp8qz6MMUz+bg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/fixer-formatter": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-15.2.0.tgz",
-      "integrity": "sha512-BOPfs+pkLhA3ai4SmtckjLFIR5PQFQGxFriSRT+E2X6ANSvdr8t/YXbM3Ysu2bFmqqXaS4m/PWkDUePhN7c0KQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-15.2.1.tgz",
+      "integrity": "sha512-8TFs76YGJ+1rkIjQ5YXV4xhomYrkaMoqqST9d7UfGE1anj9koXNhSV4V8IHlK68dAQ91Qcc6Cdz/ohZ6Mv1t9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/module-interop": "15.2.0",
-        "@textlint/resolver": "15.2.0",
-        "@textlint/types": "15.2.0",
+        "@textlint/module-interop": "15.2.1",
+        "@textlint/resolver": "15.2.1",
+        "@textlint/types": "15.2.1",
         "chalk": "^4.1.2",
         "debug": "^4.4.1",
         "diff": "^5.2.0",
@@ -2606,36 +2606,36 @@
       }
     },
     "node_modules/@textlint/kernel": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-15.2.0.tgz",
-      "integrity": "sha512-OeavhKE86qn8Js7TY9vStrduORy882eUVcv18LCLwnN7SW3/Zu/2kvBX8GBK95lGXFxnj1tXeidCl34t8/QjBQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-15.2.1.tgz",
+      "integrity": "sha512-Xen6wfOlZZtGPsXqk9enXlXxsDy3uXBQo+fENXohT0e6xnx500r4N6IrYOr/VANMoAS2DrIrqpN6Q1W1VpBZlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.2.0",
-        "@textlint/ast-tester": "15.2.0",
-        "@textlint/ast-traverse": "15.2.0",
-        "@textlint/feature-flag": "15.2.0",
-        "@textlint/source-code-fixer": "15.2.0",
-        "@textlint/types": "15.2.0",
-        "@textlint/utils": "15.2.0",
+        "@textlint/ast-node-types": "15.2.1",
+        "@textlint/ast-tester": "15.2.1",
+        "@textlint/ast-traverse": "15.2.1",
+        "@textlint/feature-flag": "15.2.1",
+        "@textlint/source-code-fixer": "15.2.1",
+        "@textlint/types": "15.2.1",
+        "@textlint/utils": "15.2.1",
         "debug": "^4.4.1",
         "fast-equals": "^4.0.3",
         "structured-source": "^4.0.0"
       }
     },
     "node_modules/@textlint/linter-formatter": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.2.0.tgz",
-      "integrity": "sha512-L+fM2OTs17hRxPCLKUdPjHce7cJp81gV9ku53FCL+cXnq5bZx0XYYkqKdtC0jnXujkQmrTYU3SYFrb4DgXqbtA==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.2.1.tgz",
+      "integrity": "sha512-oollG/BHa07+mMt372amxHohteASC+Zxgollc1sZgiyxo4S6EuureV3a4QIQB0NecA+Ak3d0cl0WI/8nou38jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azu/format-text": "^1.0.2",
         "@azu/style-format": "^1.0.1",
-        "@textlint/module-interop": "15.2.0",
-        "@textlint/resolver": "15.2.0",
-        "@textlint/types": "15.2.0",
+        "@textlint/module-interop": "15.2.1",
+        "@textlint/resolver": "15.2.1",
+        "@textlint/types": "15.2.1",
         "chalk": "^4.1.2",
         "debug": "^4.4.1",
         "js-yaml": "^3.14.1",
@@ -2648,13 +2648,13 @@
       }
     },
     "node_modules/@textlint/markdown-to-ast": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-15.2.0.tgz",
-      "integrity": "sha512-vwZaZhw0bUPP244d2RWXaSdIWPoo0fuGfy+fagkVsP559eRWV8bzm/79KraQgNGL6o2Vedy08qFt8iNvNIJBdw==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-15.2.1.tgz",
+      "integrity": "sha512-JU3AxIAuom/ZdKok6tkNVy8PsqjxKnSlBfld1dzyRV7/VFWbBuFdlaV6M8aJHa0HKy0Y9QHTXxiOJQkUPA5kWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.2.0",
+        "@textlint/ast-node-types": "15.2.1",
         "debug": "^4.4.1",
         "mdast-util-gfm-autolink-literal": "^0.1.3",
         "neotraverse": "^0.6.18",
@@ -2682,19 +2682,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@textlint/markdown-to-ast/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@textlint/markdown-to-ast/node_modules/mdast-util-find-and-replace": {
@@ -2777,9 +2764,9 @@
       }
     },
     "node_modules/@textlint/module-interop": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.2.0.tgz",
-      "integrity": "sha512-M3y1s2dZZH8PSHo4RUlnPOdK3qN90wmYGaEdy+il9/BQfrrift7S9R8lOfhHoPS0m9FEsnwyj3dQLkCUugPd9Q==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.2.1.tgz",
+      "integrity": "sha512-b/C/ZNrm05n1ypymDknIcpkBle30V2ZgE3JVqQlA9PnQV46Ky510qrZk6s9yfKgA3m1YRnAw04m8xdVtqjq1qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2796,83 +2783,70 @@
         "lodash.uniqwith": "^4.5.0"
       }
     },
-    "node_modules/@textlint/regexp-string-matcher/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@textlint/resolver": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.2.0.tgz",
-      "integrity": "sha512-1UC+5bEtuoht7uu0uGofb7sX7j17Mvyst9InrRtI4XgKhh1uMZz5YFiMYpNwry1GgCZvq7Wyq1fqtEIsvYWqFw==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.2.1.tgz",
+      "integrity": "sha512-FY3aK4tElEcOJVUsaMj4Zro4jCtKEEwUMIkDL0tcn6ljNcgOF7Em+KskRRk/xowFWayqDtdz5T3u7w/6fjjuJQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/source-code-fixer": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-15.2.0.tgz",
-      "integrity": "sha512-ynq+GMwnEF5itHljhgAk2xfuIzgy9Vj1NjBrK9S3GQQXZ0Hqq/dDzEUftA6t2Ik0o/7rWRV7Ebqr0NwFYs0/nA==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-15.2.1.tgz",
+      "integrity": "sha512-wMjEcH2jWfCazj2paNo5S+mnpf/ephOWceNQ5Aq1jfWCcqyJEvF8xykiCW7iFiW/KVkVIUdTdcrb+ZgY1n5bzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/types": "15.2.0",
+        "@textlint/types": "15.2.1",
         "debug": "^4.4.1"
       }
     },
     "node_modules/@textlint/text-to-ast": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-15.2.0.tgz",
-      "integrity": "sha512-lbznb8RnVXyUrbBgImAwD7B/ToaYBCZOc3pAJY1Uhkz76zh2Dp2PA5/l9jzR7uBJ6xYNnq/X1VPEJ6R1o1pVbQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-15.2.1.tgz",
+      "integrity": "sha512-m6j+35PfBB1pWRQ7oddKhZWMPIqeEdGvQDyFvr50piyjiJ4ME7ASVhfvA3yoLQ+92jW/DWRQ+gpj0tQPdlmq8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.2.0"
+        "@textlint/ast-node-types": "15.2.1"
       }
     },
     "node_modules/@textlint/textlint-plugin-markdown": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-15.2.0.tgz",
-      "integrity": "sha512-ErPdTe31gwTu8EcgI9QXtZAxnFDhhvShRF+S7YvZi3Uhrw0DYlbRFs7+0qRzKZk9Z/2GFGlZr3kqcnYOzwAUiA==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-15.2.1.tgz",
+      "integrity": "sha512-mHWjpGsVeIgVkWeW+H9sMhxKN/FNVofbqwwERg0vxme37vEVKrAXAq9t25ZL5erco5qkvuWT55LmgKOQG48oXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/markdown-to-ast": "15.2.0",
-        "@textlint/types": "15.2.0"
+        "@textlint/markdown-to-ast": "15.2.1",
+        "@textlint/types": "15.2.1"
       }
     },
     "node_modules/@textlint/textlint-plugin-text": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-15.2.0.tgz",
-      "integrity": "sha512-Z8+A2xiUeh5Glro5WiRdFCAFOVMCq/csp4teGWWtAczIkZg/oxlT8wScclDhKCyYdQCBaq8QYD8ArHfy00xKew==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-15.2.1.tgz",
+      "integrity": "sha512-KI5vEEQXZJmEOrVuCeYVYHZLA6tWehwrvAYNjZLnlBICD8CTPLaFm3kqlDdGosbYnsk525BhEjW6sxAeA25a6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/text-to-ast": "15.2.0",
-        "@textlint/types": "15.2.0"
+        "@textlint/text-to-ast": "15.2.1",
+        "@textlint/types": "15.2.1"
       }
     },
     "node_modules/@textlint/types": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.2.0.tgz",
-      "integrity": "sha512-wpF+xjGJgJK2JiwUdYjuNZrbuas3KfC9VDnHKac6aBLFyrI1iXuXtuxKXQDFi5/hebACactSJOuVVbuQbdJZ1Q==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.2.1.tgz",
+      "integrity": "sha512-zyqNhSatK1cwxDUgosEEN43hFh3WCty9Zm2Vm3ogU566IYegifwqN54ey/CiRy/DiO4vMcFHykuQnh2Zwp6LLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.2.0"
+        "@textlint/ast-node-types": "15.2.1"
       }
     },
     "node_modules/@textlint/utils": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-15.2.0.tgz",
-      "integrity": "sha512-4S2RveIjzvCTG6/c/Aut0DcmLsT4XGTVzvUc+yVc2/vpdMGcD97CU2o8e8CgCXGkXQNmD43OzYmr+J2MzZitWQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-15.2.1.tgz",
+      "integrity": "sha512-osXG48HjqaOk21mX3upTmAMhEEIULjzZgH17S4pQzrU/16N0VsuiqYOZL14uN0gyWR8YY8lec+cszDN/eCwULg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3912,9 +3886,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/language-core": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.3.tgz",
-      "integrity": "sha512-I9wY0ULMN9tMSua+2C7g+ez1cIziVMUzIHlDYGSl2rtru3Eh4sXj95vZ+4GBuXwwPnEmYfzSApVbXiVbI8V5Gg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.4.tgz",
+      "integrity": "sha512-BvueED4LfBCSNH66eeUQk37MQCb7hjdezzGgxniM0LbriW53AJIyLorgshAtStmjfsAuOCcTl/c1b+nz/ye8xQ==",
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.20",
@@ -4554,14 +4528,14 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.2.tgz",
-      "integrity": "sha512-hMkETCRV4hwBAvjQY1/xGw15tlPj+7cM4d5HOlYJJFftLQVRCboVX+mT6AJ6eL0fsqUhSUwDiF+pgfTR2r2Hxg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
+      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "hookified": "^1.10.0",
-        "keyv": "^5.3.4"
+        "keyv": "^5.4.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -6211,9 +6185,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.190",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
-      "integrity": "sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==",
+      "version": "1.5.191",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.191.tgz",
+      "integrity": "sha512-xcwe9ELcuxYLUFqZZxL19Z6HVKcvNkIwhbHUz7L3us6u12yR+7uY89dSl570f/IqNthx8dAw3tojG7i4Ni4tDA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6461,12 +6435,13 @@
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6802,13 +6777,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
-      "integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
+      "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.10"
+        "flat-cache": "^6.1.12"
       }
     },
     "node_modules/file-saver": {
@@ -6876,13 +6851,13 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.11.tgz",
-      "integrity": "sha512-zfOAns94mp7bHG/vCn9Ru2eDCmIxVQ5dELUHKjHfDEOJmHNzE+uGa6208kfkgmtym4a0FFjEuFksCXFacbVhSg==",
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
+      "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.10.1",
+        "cacheable": "^1.10.3",
         "flatted": "^3.3.3",
         "hookified": "^1.10.0"
       }
@@ -8584,9 +8559,9 @@
       "license": "MIT"
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9076,6 +9051,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-footnote": {
@@ -11682,19 +11669,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/remark-gfm/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/remark-gfm/node_modules/longest-streak": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
@@ -13223,26 +13197,26 @@
       "license": "MIT"
     },
     "node_modules/textlint": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/textlint/-/textlint-15.2.0.tgz",
-      "integrity": "sha512-UuJOkbbWsMrWDLVU65h54yoFByVGTiVrr9EJFEUDCoWxR2Nye+3wABS8T4uoc5qyeY+27mGwQO/6jQid37aioA==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/textlint/-/textlint-15.2.1.tgz",
+      "integrity": "sha512-FChEKsi81lcjv9ZucXpbMNA3HQw27eafUw0F7fyiX56u8eNr2rSb5oAtZO0DF6a+/bNDe8W7NG3BxOAPsWFoDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.13.2",
-        "@textlint/ast-node-types": "15.2.0",
-        "@textlint/ast-traverse": "15.2.0",
-        "@textlint/config-loader": "15.2.0",
-        "@textlint/feature-flag": "15.2.0",
-        "@textlint/fixer-formatter": "15.2.0",
-        "@textlint/kernel": "15.2.0",
-        "@textlint/linter-formatter": "15.2.0",
-        "@textlint/module-interop": "15.2.0",
-        "@textlint/resolver": "15.2.0",
-        "@textlint/textlint-plugin-markdown": "15.2.0",
-        "@textlint/textlint-plugin-text": "15.2.0",
-        "@textlint/types": "15.2.0",
-        "@textlint/utils": "15.2.0",
+        "@modelcontextprotocol/sdk": "^1.15.1",
+        "@textlint/ast-node-types": "15.2.1",
+        "@textlint/ast-traverse": "15.2.1",
+        "@textlint/config-loader": "15.2.1",
+        "@textlint/feature-flag": "15.2.1",
+        "@textlint/fixer-formatter": "15.2.1",
+        "@textlint/kernel": "15.2.1",
+        "@textlint/linter-formatter": "15.2.1",
+        "@textlint/module-interop": "15.2.1",
+        "@textlint/resolver": "15.2.1",
+        "@textlint/textlint-plugin-markdown": "15.2.1",
+        "@textlint/textlint-plugin-text": "15.2.1",
+        "@textlint/types": "15.2.1",
+        "@textlint/utils": "15.2.1",
         "debug": "^4.4.1",
         "file-entry-cache": "^10.1.1",
         "glob": "^10.4.5",
@@ -13254,7 +13228,7 @@
         "read-package-up": "^11.0.0",
         "structured-source": "^4.0.0",
         "unique-concat": "^0.2.2",
-        "zod": "^3.25.67"
+        "zod": "^3.25.76"
       },
       "bin": {
         "textlint": "bin/textlint.js"
@@ -14031,19 +14005,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/textlint-tester/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/textlint-tester/node_modules/mdast-util-find-and-replace": {
@@ -14839,6 +14800,19 @@
         "node": ">=18.12.0"
       }
     },
+    "node_modules/unimport/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unimport/node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -15340,14 +15314,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.5.tgz",
-      "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
+      "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
-        "picomatch": "^4.0.2",
+        "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.40.0",
         "tinyglobby": "^0.2.14"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@slidev/cli": "^52.0.0",
     "@slidev/theme-default": "^0.25.0",
     "@slidev/theme-seriph": "^0.25.0",
-    "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.0",
     "slidev-addon-components": "^0.0.1",
     "slidev-addon-rabbit": "^0.4.0"
   },
@@ -38,6 +37,7 @@
     "@iconify-json/ph": "^1.2.2",
     "@iconify-json/simple-icons": "^1.2.44",
     "@iconify-json/tabler": "^1.2.20",
+    "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.0",
     "playwright-chromium": "^1.54.1",
     "textlint": "^15.2.0",
     "textlint-filter-rule-comments": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@iconify-json/tabler": "^1.2.20",
     "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.0",
     "playwright-chromium": "^1.54.1",
-    "textlint": "^15.2.0",
+    "textlint": "^15.2.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-preset-ja-spacing": "^2.4.3",
     "textlint-rule-preset-ja-technical-writing": "^12.0.2"


### PR DESCRIPTION
- Updated textlint from ^15.2.0 to ^15.2.1 in package.json
- Updated various dependencies in package-lock.json to their latest versions, including:
  - @babel/helpers to 7.28.2
  - @babel/types to 7.28.2
  - @modelcontextprotocol/sdk to 1.17.0
  - @textlint/ast-node-types, @textlint/ast-tester, @textlint/ast-traverse, @textlint/config-loader, @textlint/feature-flag, @textlint/fixer-formatter, @textlint/kernel, @textlint/linter-formatter, @textlint/module-interop, @textlint/resolver, @textlint/source-code-fixer, @textlint/text-to-ast, @textlint/textlint-plugin-markdown, @textlint/textlint-plugin-text, @textlint/types, @textlint/utils to 15.2.1
  - Updated other dependencies such as cacheable, electron-to-chromium, file-entry-cache, flat-cache, jiti, vite, and picomatch to their latest versions.